### PR TITLE
Add service listeners

### DIFF
--- a/PaymentInitiationSample/src/main/AndroidManifest.xml
+++ b/PaymentInitiationSample/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
           package="com.aevi.sdk.pos.flow.paymentinitiationsample">
 
     <application
@@ -7,7 +8,9 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:ignore="GoogleAppIndexingWarning">
+
         <activity android:name=".ui.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
@@ -33,6 +36,23 @@
             android:label="@string/payment_result"
             android:theme="@style/Popup">
         </activity>
+
+        <service
+            android:name=".PaymentResponseListenerService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.aevi.sdk.flow.listener.PAYMENT_RESPONSE"/>
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".ResponseListenerService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.aevi.sdk.flow.listener.RESPONSE"/>
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/PaymentInitiationSample/src/main/AndroidManifest.xml
+++ b/PaymentInitiationSample/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
             android:name=".PaymentResponseListenerService"
             android:exported="true">
             <intent-filter>
-                <action android:name="com.aevi.sdk.flow.listener.PAYMENT_RESPONSE"/>
+                <action android:name="com.aevi.sdk.flow.action.PAYMENT_RESPONSE"/>
             </intent-filter>
         </service>
 
@@ -49,7 +49,7 @@
             android:name=".ResponseListenerService"
             android:exported="true">
             <intent-filter>
-                <action android:name="com.aevi.sdk.flow.listener.RESPONSE"/>
+                <action android:name="com.aevi.sdk.flow.action.RESPONSE"/>
             </intent-filter>
         </service>
 

--- a/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/PaymentResponseListenerService.java
+++ b/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/PaymentResponseListenerService.java
@@ -1,3 +1,16 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.aevi.sdk.pos.flow.paymentinitiationsample;
 
 import android.util.Log;

--- a/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/PaymentResponseListenerService.java
+++ b/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/PaymentResponseListenerService.java
@@ -1,0 +1,14 @@
+package com.aevi.sdk.pos.flow.paymentinitiationsample;
+
+import android.util.Log;
+
+import com.aevi.sdk.pos.flow.model.PaymentResponse;
+import com.aevi.sdk.pos.flow.service.BasePaymentResponseListenerService;
+
+public class PaymentResponseListenerService extends BasePaymentResponseListenerService {
+
+    @Override
+    protected void notifyResponse(PaymentResponse paymentResponse) {
+        Log.d("XXX", "GOT RESPONSE UPDATE: " + paymentResponse.toJson());
+    }
+}

--- a/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/PaymentResponseListenerService.java
+++ b/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/PaymentResponseListenerService.java
@@ -7,8 +7,10 @@ import com.aevi.sdk.pos.flow.service.BasePaymentResponseListenerService;
 
 public class PaymentResponseListenerService extends BasePaymentResponseListenerService {
 
+    private static final String TAG = PaymentResponseListenerService.class.getSimpleName();
+
     @Override
     protected void notifyResponse(PaymentResponse paymentResponse) {
-        Log.d("XXX", "GOT RESPONSE UPDATE: " + paymentResponse.toJson());
+        Log.d(TAG, "Got response in payment response listener: " + paymentResponse.toJson());
     }
 }

--- a/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/ResponseListenerService.java
+++ b/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/ResponseListenerService.java
@@ -1,3 +1,16 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package com.aevi.sdk.pos.flow.paymentinitiationsample;
 
 import android.util.Log;

--- a/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/ResponseListenerService.java
+++ b/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/ResponseListenerService.java
@@ -1,0 +1,14 @@
+package com.aevi.sdk.pos.flow.paymentinitiationsample;
+
+import android.util.Log;
+
+import com.aevi.sdk.flow.model.Response;
+import com.aevi.sdk.flow.service.BaseResponseListenerService;
+
+public class ResponseListenerService extends BaseResponseListenerService {
+
+    @Override
+    protected void notifyResponse(Response response) {
+        Log.d("XXX", "GOT RESPONSE UPDATE: " + response.toJson());
+    }
+}

--- a/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/ResponseListenerService.java
+++ b/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/ResponseListenerService.java
@@ -7,8 +7,10 @@ import com.aevi.sdk.flow.service.BaseResponseListenerService;
 
 public class ResponseListenerService extends BaseResponseListenerService {
 
+    private static final String TAG = ResponseListenerService.class.getSimpleName();
+
     @Override
     protected void notifyResponse(Response response) {
-        Log.d("XXX", "GOT RESPONSE UPDATE: " + response.toJson());
+        Log.d(TAG, "Got response in listener: " + response.toJson());
     }
 }

--- a/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/ui/RequestInitiationActivity.java
+++ b/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/ui/RequestInitiationActivity.java
@@ -21,10 +21,13 @@ import com.aevi.sdk.pos.flow.paymentinitiationsample.R;
 import com.aevi.sdk.pos.flow.sample.ui.ModelDisplay;
 
 import butterknife.ButterKnife;
+import io.reactivex.disposables.Disposable;
 
 public class RequestInitiationActivity extends AppCompatActivity {
 
     private ModelDisplay modelDisplay;
+
+    private Disposable disposable;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/ui/RequestInitiationActivity.java
+++ b/PaymentInitiationSample/src/main/java/com/aevi/sdk/pos/flow/paymentinitiationsample/ui/RequestInitiationActivity.java
@@ -21,13 +21,10 @@ import com.aevi.sdk.pos.flow.paymentinitiationsample.R;
 import com.aevi.sdk.pos.flow.sample.ui.ModelDisplay;
 
 import butterknife.ButterKnife;
-import io.reactivex.disposables.Disposable;
 
 public class RequestInitiationActivity extends AppCompatActivity {
 
     private ModelDisplay modelDisplay;
-
-    private Disposable disposable;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/PaymentServiceSample/src/main/java/com/aevi/sdk/pos/flow/paymentservicesample/service/PaymentProcessingService.java
+++ b/PaymentServiceSample/src/main/java/com/aevi/sdk/pos/flow/paymentservicesample/service/PaymentProcessingService.java
@@ -15,8 +15,8 @@
 package com.aevi.sdk.pos.flow.paymentservicesample.service;
 
 
-import com.aevi.sdk.pos.flow.paymentservicesample.ui.PaymentResponseBuilderActivity;
 import com.aevi.sdk.pos.flow.model.TransactionRequest;
+import com.aevi.sdk.pos.flow.paymentservicesample.ui.PaymentResponseBuilderActivity;
 import com.aevi.sdk.pos.flow.service.BasePaymentProcessingService;
 
 public class PaymentProcessingService extends BasePaymentProcessingService {

--- a/flow-base-api/src/main/java/com/aevi/sdk/flow/BaseApiClient.java
+++ b/flow-base-api/src/main/java/com/aevi/sdk/flow/BaseApiClient.java
@@ -25,7 +25,12 @@ import android.support.annotation.NonNull;
 
 import com.aevi.android.rxmessenger.client.ObservableMessengerClient;
 import com.aevi.sdk.flow.constants.AppMessageTypes;
-import com.aevi.sdk.flow.model.*;
+import com.aevi.sdk.flow.model.AppMessage;
+import com.aevi.sdk.flow.model.Device;
+import com.aevi.sdk.flow.model.FlowEvent;
+import com.aevi.sdk.flow.model.InternalData;
+import com.aevi.sdk.flow.model.Request;
+import com.aevi.sdk.flow.model.Response;
 
 import java.util.List;
 
@@ -39,7 +44,7 @@ import io.reactivex.functions.Function;
  */
 public abstract class BaseApiClient {
 
-    protected static final String FLOW_PROCESSING_SERVICE = "com.aevi.sdk.fps";
+    public static final String FLOW_PROCESSING_SERVICE = "com.aevi.sdk.fps";
     protected static final ComponentName FLOW_PROCESSING_SERVICE_COMPONENT = new ComponentName(FLOW_PROCESSING_SERVICE, FLOW_PROCESSING_SERVICE + ".FlowProcessingService");
     protected static final ComponentName REQUEST_STATUS_SERVICE_COMPONENT = new ComponentName(FLOW_PROCESSING_SERVICE, FLOW_PROCESSING_SERVICE + ".RequestStatusService");
     protected static final ComponentName SYSTEM_EVENT_SERVICE_COMPONENT = new ComponentName(FLOW_PROCESSING_SERVICE, FLOW_PROCESSING_SERVICE + ".SystemEventService");

--- a/flow-base-api/src/main/java/com/aevi/sdk/flow/service/BaseApiService.java
+++ b/flow-base-api/src/main/java/com/aevi/sdk/flow/service/BaseApiService.java
@@ -58,7 +58,7 @@ public abstract class BaseApiService<REQUEST extends Jsonable, RESPONSE extends 
     protected final void handleRequest(String clientMessageId, String message, String packageName) {
         Log.d(TAG, "Received message: " + message);
         AppMessage appMessage = AppMessage.fromJson(message);
-        checkVersions(appMessage);
+        checkVersions(appMessage, internalData);
         switch (appMessage.getMessageType()) {
             case REQUEST_MESSAGE:
                 handleRequestMessage(clientMessageId, appMessage.getMessageData(), packageName);
@@ -73,15 +73,15 @@ public abstract class BaseApiService<REQUEST extends Jsonable, RESPONSE extends 
         }
     }
 
-    private void checkVersions(AppMessage appMessage) {
+    static void checkVersions(AppMessage appMessage, InternalData checkWith) {
         // All we do for now is log this - at some point we might want to have specific checks or whatevs
         InternalData senderInternalData = appMessage.getInternalData();
         if (senderInternalData != null) {
-            Log.i(TAG, String.format("Our API version is: %s. Sender API version is: %s",
-                    internalData.getSenderApiVersion(),
+            Log.i(BaseApiService.class.getSimpleName(), String.format("Our API version is: %s. Sender API version is: %s",
+                    checkWith.getSenderApiVersion(),
                     senderInternalData.getSenderApiVersion()));
         } else {
-            Log.i(TAG, String.format("Our API version is: %s. Sender API version is UNKNOWN!", internalData.getSenderApiVersion()));
+            Log.i(BaseApiService.class.getSimpleName(), String.format("Our API version is: %s. Sender API version is UNKNOWN!", checkWith.getSenderApiVersion()));
         }
     }
 

--- a/flow-base-api/src/main/java/com/aevi/sdk/flow/service/BaseListenerService.java
+++ b/flow-base-api/src/main/java/com/aevi/sdk/flow/service/BaseListenerService.java
@@ -1,0 +1,60 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.aevi.sdk.flow.service;
+
+import com.aevi.android.rxmessenger.service.AbstractMessengerService;
+import com.aevi.sdk.flow.constants.AppMessageTypes;
+import com.aevi.sdk.flow.model.AppMessage;
+import com.aevi.sdk.flow.model.BaseModel;
+import com.aevi.sdk.flow.model.InternalData;
+import com.aevi.util.json.JsonConverter;
+
+import static com.aevi.sdk.flow.BaseApiClient.FLOW_PROCESSING_SERVICE;
+import static com.aevi.sdk.flow.constants.AppMessageTypes.REQUEST_ACK_MESSAGE;
+import static com.aevi.sdk.flow.service.BaseApiService.checkVersions;
+
+public abstract class BaseListenerService<RESPONSE extends BaseModel> extends AbstractMessengerService {
+
+    private final Class<RESPONSE> responseClass;
+    private final InternalData internalData;
+
+    protected BaseListenerService(Class<RESPONSE> responseClass, String apiVersion) {
+        this.responseClass = responseClass;
+        internalData = new InternalData(apiVersion);
+    }
+
+    @Override
+    protected void handleRequest(String clientMessageId, String message, String packageName) {
+        sendAck(clientMessageId);
+        sendEndStreamMessageToClient(clientMessageId);
+        if (FLOW_PROCESSING_SERVICE.equals(packageName)) {
+            AppMessage appMessage = AppMessage.fromJson(message);
+            checkVersions(appMessage, internalData);
+
+            if (AppMessageTypes.RESPONSE_MESSAGE.equals(appMessage.getMessageType())) {
+                RESPONSE response = JsonConverter.deserialize(appMessage.getMessageData(), responseClass);
+                if (response != null) {
+                    notifyResponse(response);
+                }
+            }
+        }
+    }
+
+    private void sendAck(String clientMessageId) {
+        AppMessage appMessage = new AppMessage(REQUEST_ACK_MESSAGE, internalData);
+        sendMessageToClient(clientMessageId, appMessage.toJson());
+    }
+
+    protected abstract void notifyResponse(RESPONSE response);
+}

--- a/flow-base-api/src/main/java/com/aevi/sdk/flow/service/BaseListenerService.java
+++ b/flow-base-api/src/main/java/com/aevi/sdk/flow/service/BaseListenerService.java
@@ -24,6 +24,12 @@ import static com.aevi.sdk.flow.BaseApiClient.FLOW_PROCESSING_SERVICE;
 import static com.aevi.sdk.flow.constants.AppMessageTypes.REQUEST_ACK_MESSAGE;
 import static com.aevi.sdk.flow.service.BaseApiService.checkVersions;
 
+/**
+ * Base service used for notifying clients of the final response for any transaction.
+ *
+ * This class should not be used directly instead choose one of the child classes
+ * e.g. for generic responses use {@link BaseResponseListenerService}.
+ */
 public abstract class BaseListenerService<RESPONSE extends BaseModel> extends AbstractMessengerService {
 
     private final Class<RESPONSE> responseClass;
@@ -56,5 +62,11 @@ public abstract class BaseListenerService<RESPONSE extends BaseModel> extends Ab
         sendMessageToClient(clientMessageId, appMessage.toJson());
     }
 
+    /**
+     * This method will be called with the appropriate response for clients that initiated the matching request or flow services that have
+     * processed the request in some way and require to be notified of the final response
+     *
+     * @param response The final response sent after completion of a flow
+     */
     protected abstract void notifyResponse(RESPONSE response);
 }

--- a/flow-base-api/src/main/java/com/aevi/sdk/flow/service/BaseResponseListenerService.java
+++ b/flow-base-api/src/main/java/com/aevi/sdk/flow/service/BaseResponseListenerService.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.aevi.sdk.flow.service;
+
+import com.aevi.sdk.flow.FlowBaseConfig;
+import com.aevi.sdk.flow.model.Response;
+
+/**
+ * Extend this service in your application if you want to listen to responses for requests initiated by your application.
+ *
+ * OR If you are implementing a flow service then extend this service to listen to the final `Response` when the flow is complete.
+ *
+ * In either case you must extend this service in your own application and register it correctly in your manifest. The service must
+ * be exported and must include the intent-filter "com.aevi.sdk.flow.listener.RESPONSE"
+ *
+ * {@code
+ *
+ * <service
+ * android:name=".ResponseListenerService"
+ * android:exported="true">
+ * <intent-filter>
+ * <action android:name="com.aevi.sdk.flow.listener.RESPONSE"/>
+ * </intent-filter>
+ * </service>
+ * }
+ *
+ * The service will be called asynchronously by the flow processing service. Therefore, the original request may have completed before this is called.
+ *
+ * This service can be used to verify a response and/or recover from crashes or issues in your application that may have prevented the response being
+ * received in the original initiation call.
+ */
+public abstract class BaseResponseListenerService extends BaseListenerService<Response> {
+
+    protected BaseResponseListenerService() {
+        super(Response.class, FlowBaseConfig.VERSION);
+    }
+}

--- a/flow-base-api/src/test/java/com/aevi/sdk/flow/service/BaseListenerServiceTest.java
+++ b/flow-base-api/src/test/java/com/aevi/sdk/flow/service/BaseListenerServiceTest.java
@@ -1,0 +1,96 @@
+package com.aevi.sdk.flow.service;
+
+import com.aevi.sdk.flow.constants.AppMessageTypes;
+import com.aevi.sdk.flow.model.AppMessage;
+import com.aevi.sdk.flow.model.Request;
+import com.aevi.sdk.flow.model.Response;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.aevi.sdk.flow.BaseApiClient.FLOW_PROCESSING_SERVICE;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class BaseListenerServiceTest {
+
+    TestListenerService listenerService;
+    Response response;
+    AppMessage incomingAppMessage;
+
+    @Before
+    public void setUp() throws Exception {
+        listenerService = new TestListenerService();
+        response = new Response(new Request("banana"), true, "Believe!");
+        incomingAppMessage = new AppMessage(AppMessageTypes.RESPONSE_MESSAGE, response.toJson());
+    }
+
+    @Test
+    public void shouldSendAckOnResponseMessage() {
+        listenerService.fakeIncomingMessage(incomingAppMessage, FLOW_PROCESSING_SERVICE);
+
+        assertThat(listenerService.messageSent.getMessageType()).isEqualTo(AppMessageTypes.REQUEST_ACK_MESSAGE);
+        assertThat(listenerService.endStreamSent).isTrue();
+    }
+
+    @Test
+    public void shouldPassOnResponseMessage() {
+        listenerService.fakeIncomingMessage(incomingAppMessage, FLOW_PROCESSING_SERVICE);
+
+        assertThat(listenerService.responseCalled).isTrue();
+        assertThat(listenerService.responseReceived).isEqualTo(response);
+        assertThat(listenerService.endStreamSent).isTrue();
+    }
+
+    @Test
+    public void willIgnoreMessageFromOtherPackages() {
+        listenerService.fakeIncomingMessage(incomingAppMessage, "com.nefarious.app");
+
+        assertThat(listenerService.responseCalled).isFalse();
+        assertThat(listenerService.responseReceived).isNull();
+        assertThat(listenerService.endStreamSent).isTrue();
+    }
+
+    @Test
+    public void willIgnoreWrongMessageType() {
+        AppMessage wrongIncomingAppMessage = new AppMessage(AppMessageTypes.REQUEST_MESSAGE, response.toJson());
+        listenerService.fakeIncomingMessage(wrongIncomingAppMessage, FLOW_PROCESSING_SERVICE);
+
+        assertThat(listenerService.responseCalled).isFalse();
+        assertThat(listenerService.responseReceived).isNull();
+        assertThat(listenerService.endStreamSent).isTrue();
+    }
+
+    class TestListenerService extends BaseListenerService<Response> {
+
+        Response responseReceived;
+        boolean endStreamSent;
+        boolean responseCalled;
+        AppMessage messageSent;
+
+        protected TestListenerService() {
+            super(Response.class, "1.0.0");
+        }
+
+        void fakeIncomingMessage(AppMessage appMessage, String packageName) {
+            handleRequest("123", appMessage.toJson(), packageName);
+        }
+
+        @Override
+        protected void notifyResponse(Response response) {
+            responseCalled = true;
+            responseReceived = response;
+        }
+
+        @Override
+        public boolean sendEndStreamMessageToClient(String clientId) {
+            endStreamSent = true;
+            return true;
+        }
+
+        @Override
+        public boolean sendMessageToClient(String clientId, String response) {
+            messageSent = AppMessage.fromJson(response);
+            return true;
+        }
+    }
+}

--- a/payment-initiation-api/src/main/java/com/aevi/sdk/pos/flow/service/BasePaymentResponseListenerService.java
+++ b/payment-initiation-api/src/main/java/com/aevi/sdk/pos/flow/service/BasePaymentResponseListenerService.java
@@ -1,0 +1,49 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.aevi.sdk.pos.flow.service;
+
+import com.aevi.sdk.flow.service.BaseListenerService;
+import com.aevi.sdk.pos.flow.PaymentInitiationConfig;
+import com.aevi.sdk.pos.flow.model.PaymentResponse;
+
+/**
+ * Extend this service in your application if you want to listen to payment responses initiated by your application.
+ *
+ * OR If you are implementing a flow service then extend this service to listen to the final `PaymentResponse` when the flow is complete.
+ *
+ * In either case you must extend this service in your own application and register it correctly in your manifest. The service must
+ * be exported and must include the intent-filter "com.aevi.sdk.flow.listener.PAYMENT_RESPONSE"
+ *
+ * {@code
+ *
+ * <service
+ * android:name=".PaymentResponseListenerService"
+ * android:exported="true">
+ * <intent-filter>
+ * <action android:name="com.aevi.sdk.flow.listener.PAYMENT_RESPONSE"/>
+ * </intent-filter>
+ * </service>
+ * }
+ *
+ * The service will be called asynchronously by the flow processing service. Therefore, the original request may have completed before this is called.
+ *
+ * This service can be used to verify a response and/or recover from crashes or issues in your application that may have prevented the response being
+ * received in the original initiation call.
+ */
+public abstract class BasePaymentResponseListenerService extends BaseListenerService<PaymentResponse> {
+
+    protected BasePaymentResponseListenerService() {
+        super(PaymentResponse.class, PaymentInitiationConfig.VERSION);
+    }
+}


### PR DESCRIPTION
These can be used by initiation and flow service applications to "listen" to the final response from FPS. This allows an app to potentially recover if it has not processed a response correctly.